### PR TITLE
deduction-guide grammar fix for P0892

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8667,7 +8667,7 @@ any deduction guides declared for the class template are considered.
 
 \begin{bnf}
 \nontermdef{deduction-guide}\br
-    \terminal{explicit}\opt{} template-name \terminal{(} parameter-declaration-clause \terminal{) ->} simple-template-id \terminal{;}
+    \grammarterm{explicit-specifier}\opt{} template-name \terminal{(} parameter-declaration-clause \terminal{) ->} simple-template-id \terminal{;}
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
should have a conditional _explicit-specifier_ instead of conditional `explicit`